### PR TITLE
Fix removeEventListener error (PixiJS 7)

### DIFF
--- a/src/InputManager.ts
+++ b/src/InputManager.ts
@@ -77,7 +77,7 @@ export class InputManager
      */
     public destroy(): void
     {
-        this.viewport.options.events.domElement.removeEventListener('wheel', this.wheelFunction as any);
+        this.viewport.options.events.domElement?.removeEventListener('wheel', this.wheelFunction as any);
     }
 
     /**

--- a/src/Viewport.ts
+++ b/src/Viewport.ts
@@ -253,7 +253,7 @@ export class Viewport extends Container
         }
         if (this.options.disableOnContextMenu)
         {
-            this.options.events.domElement.removeEventListener('contextmenu', this._disableOnContextMenu);
+            this.options.events.domElement?.removeEventListener('contextmenu', this._disableOnContextMenu);
         }
 
         this.input.destroy();


### PR DESCRIPTION
Fixes #438

This pull request adds an optional chaining operator to the `events.domElement` property when calling `removeEventListener`. This means that this will no longer error out when the Pixi prematurely destroys the domElement ahead of pixi-viewport.

Also removes the need to do this in userland for @pixi/react:
```
willUnmount: (viewport: PixiViewport) => {
    viewport.options.noTicker = true;
    viewport.destroy({ children: true });
}
```

I've tested this locally using `pnpm patch` on my application and it works wonders.